### PR TITLE
Fixed quoting of jobsub option specifying singularity image

### DIFF
--- a/scripts/project.py
+++ b/scripts/project.py
@@ -3141,7 +3141,7 @@ def dojobsub(project, stage, makeup, recur, dryrun):
         else:
             p = project_utilities.get_singularity(project.os)
             if p != '':
-                command.append('--lines=\'+SingularityImage=\\"%s\\"\'' % p)
+                command.append(r"""--lines='+SingularityImage="%s"'""" % p)
             else:
                 raise RuntimeError('No singularity image found for %s' % project.os)
     if not stage.pubs_output:


### PR DESCRIPTION
This should address [Redmine issue #25709](https://cdcvs.fnal.gov/redmine/issues/25709).

I have tried to make the quote escaping of `SingularityImage` option more robust.
Tested with a XML configuration that was failing before (no `<singularity>`, but with `<os>`, `<numjobs>` and `<inputlist>`).