### PR TITLE
Python 3.9

### DIFF
--- a/python/larbatch_utilities.py
+++ b/python/larbatch_utilities.py
@@ -71,6 +71,7 @@
 from __future__ import absolute_import
 from __future__ import print_function
 import sys, os
+import socket
 import stat
 import subprocess
 import getpass


### PR DESCRIPTION
Add missing import in larbatch_utilities.py.  This update is necessary for project.py to run using AL9 system python (3.9).