### PR TITLE
Make finding the job fcl from the submit environment optional.

### DIFF
--- a/python/projectdef.py
+++ b/python/projectdef.py
@@ -556,14 +556,19 @@ class ProjectDef:
         
         fcl_list = []
         for name in fclname:
-         fcl = ''
-         for fcldir in self.fclpath:
+          fcl_found = False
+          fcl = ''
+          for fcldir in self.fclpath:
             fcl = os.path.join(fcldir, name)
             #print fcl
             if larbatch_posix.exists(fcl):
+                fcl_found = True
                 break
-         
-         if fcl == '' or not larbatch_posix.exists(fcl):
-             raise IOError('Could not find fcl file %s.' % name)
-         fcl_list.append(fcl)      
+
+          # If we didn't find the fcl full path, just return the fcl name.
+
+          if not fcl_found:
+            fcl = name
+
+          fcl_list.append(fcl)
         return fcl_list

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -2525,9 +2525,10 @@ def dojobsub(project, stage, makeup, recur, dryrun):
     # Copy the fcl file to the work directory.
 
     for fcl in fcls:
-      workfcl = os.path.join(tmpworkdir, os.path.basename(fcl))
-      if os.path.abspath(fcl) != os.path.abspath(workfcl):
-        larbatch_posix.copy(fcl, workfcl)
+      if larbatch_posix.exists(fcl):
+        workfcl = os.path.join(tmpworkdir, os.path.basename(fcl))
+        if os.path.abspath(fcl) != os.path.abspath(workfcl):
+          larbatch_posix.copy(fcl, workfcl)
 
 
     # Construct a wrapper fcl file (called "wrapper.fcl") that will include


### PR DESCRIPTION
When submitting jobs, make finding the job fcl(s) on $FHICL_FILE_PATH in the submit environment optional.  This makes it easier to submit jobs natively in AL9.