### PR TITLE
Add artroot filter for multiple-fcl jobs.

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # Executable python files (will also be on PYTYHONPATH).
 
-LIST(APPEND exes root_metadata.py merge_json.py emptydir.py mkdir.py subruns.py stream.py extractor_dict.py)
+LIST(APPEND exes root_metadata.py merge_json.py emptydir.py mkdir.py subruns.py stream.py extractor_dict.py artroot_filter.py)
 
 # Python modules on PYTHONPATH.
 

--- a/python/artroot_filter.py
+++ b/python/artroot_filter.py
@@ -1,0 +1,87 @@
+#! /usr/bin/env python
+######################################################################
+#
+# Name: artroot_filter.py
+#
+# Purpose: Read a list of files from standard input (one per line) and
+#          output valid artroot files to standard output (also one per line).
+#
+# Usage:
+#
+# This script does not accept any command line options or arguments.
+#
+# Examples:
+#
+# ls -1 *.root | artroot_filter.py
+# cat files.list | artroot_filter.py
+#
+# Created: 7-Jan-2025  Herbert Greenlee
+#
+######################################################################
+
+from __future__ import absolute_import
+from __future__ import print_function
+import sys, os
+
+# Import ROOT module.
+# Globally turn off root warning and error messages.
+# Don't let root see our command line options.
+
+myargv = sys.argv
+sys.argv = myargv[0:1]
+if 'TERM' in os.environ:
+    del os.environ['TERM']
+import ROOT
+ROOT.gErrorIgnoreLevel = ROOT.kFatal
+sys.argv = myargv
+
+# Main program.
+
+def main(argv):
+
+    # Loop over stdin lines.
+
+    for line in sys.stdin.readlines():
+
+        # Separate line into words and only keep the first word.
+        # Blanks lines are skipped here.
+
+        words = line.split()
+        if len(words) > 0:
+            f=words[0]
+
+            # Try to open file as a root file.
+
+            root = ROOT.TFile.Open(f, 'read')
+            if root and root.IsOpen() and not root.IsZombie():
+
+                # File opened successfully.
+                # Loop over this file keys.
+                # To qualify as an artroot file, this file must contain the following objects:
+                # 1.  A TTree called 'Events'
+                # 2.  A TKey called 'RootFileDB'
+
+                has_events = False
+                has_db = False
+                keys = root.GetListOfKeys()
+                for key in keys:
+                    objname = key.GetName()
+                    obj = root.Get(objname)
+                    if objname == 'Events' and obj.InheritsFrom('TTree'):
+                        has_events = True
+                    if objname == 'RootFileDB' and obj.InheritsFrom('TKey'):
+                        has_db = True
+
+                # Is this an artroot file?  Print file name if yes.
+
+                if has_events and has_db:
+                    print(f)
+
+    # Done.
+
+    return 0
+
+# Invoke main program.
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))

--- a/python/projectdef.py
+++ b/python/projectdef.py
@@ -556,14 +556,19 @@ class ProjectDef:
         
         fcl_list = []
         for name in fclname:
-         fcl = ''
-         for fcldir in self.fclpath:
+          fcl_found = False
+          fcl = ''
+          for fcldir in self.fclpath:
             fcl = os.path.join(fcldir, name)
             #print fcl
             if larbatch_posix.exists(fcl):
+                fcl_found = True
                 break
-         
-         if fcl == '' or not larbatch_posix.exists(fcl):
-             raise IOError('Could not find fcl file %s.' % name)
-         fcl_list.append(fcl)      
+
+          # If we didn't find the fcl full path, just return the fcl name.
+
+          if not fcl_found:
+            fcl = name
+
+          fcl_list.append(fcl)
         return fcl_list

--- a/python/stagedef.py
+++ b/python/stagedef.py
@@ -100,7 +100,7 @@ class StageDef:
             self.end_script = base_stage.end_script
             self.mid_source = base_stage.mid_source
             self.mid_script = base_stage.mid_script
-            self.process_name = base_stage.pocess_name
+            self.process_name = base_stage.process_name
             self.project_name = base_stage.project_name
             self.stage_name = base_stage.stage_name
             self.project_version = base_stage.project_version

--- a/scripts/condor_lar.sh
+++ b/scripts/condor_lar.sh
@@ -1816,7 +1816,7 @@ EOF
   #echo "Outfile is $OUTFILE"
    
 
-  next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | head -n1`
+  next_stage_input=`ls -t1 *.root | egrep -v 'celltree|hist|larlite|larcv|Supplemental|TGraphs' | artroot_filter.py | head -n1`
 
   # Don't let file name get too long.
 

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -2842,6 +2842,7 @@ def dojobsub(project, stage, makeup, recur, dryrun, retain):
     # Copy helper scripts to work directory.
 
     helpers = ('root_metadata.py',
+               'artroot_filter.py',
                'merge_json.py',
                'subruns.py',
                'validate_in_job.py',

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -2528,9 +2528,10 @@ def dojobsub(project, stage, makeup, recur, dryrun, retain):
     # Copy the fcl file to the work directory.
 
     for fcl in fcls:
-      workfcl = os.path.join(tmpworkdir, os.path.basename(fcl))
-      if os.path.abspath(fcl) != os.path.abspath(workfcl):
-        larbatch_posix.copy(fcl, workfcl)
+      if larbatch_posix.exists(fcl):
+        workfcl = os.path.join(tmpworkdir, os.path.basename(fcl))
+        if os.path.abspath(fcl) != os.path.abspath(workfcl):
+          larbatch_posix.copy(fcl, workfcl)
 
 
     # Construct a wrapper fcl file (called "wrapper.fcl") that will include


### PR DESCRIPTION
In batch script condor_lar, make sure root files used as input to succeeding fcls are artroot files.

This merge request brings integration release version of larbatch to same level as MicroBooNE MCC9 branch.