### PR TITLE
Add xml element <finscript>

### DIFF
--- a/scripts/condor_lar.sh
+++ b/scripts/condor_lar.sh
@@ -2064,7 +2064,7 @@ if [ $VALIDATE_IN_JOB -eq 1 ]; then
       if [ x$FINSCRIPT != x ]; then
         finopt="--finscript $FINSCRIPT"
       fi
-      echo "./validate_in_job.py --dir $curdir/out --logfiledir $curdir/log --outdir $OUTDIR/$OUTPUT_SUBDIR --declare $DECLARE_IN_JOB --copy $COPY_TO_FTS --maintain_parentage $MAINTAIN_PARENTAGE $dataopt"
+      echo "./validate_in_job.py --dir $curdir/out --logfiledir $curdir/log --outdir $OUTDIR/$OUTPUT_SUBDIR --declare $DECLARE_IN_JOB --copy $COPY_TO_FTS --maintain_parentage $MAINTAIN_PARENTAGE $dataopt $finopt"
       ./validate_in_job.py --dir $curdir/out --logfiledir $curdir/log --outdir $OUTDIR/$OUTPUT_SUBDIR --declare $DECLARE_IN_JOB --copy $COPY_TO_FTS --maintain_parentage $MAINTAIN_PARENTAGE $dataopt $finopt
       valstat=$?
       cd $curdir

--- a/scripts/condor_lar.sh
+++ b/scripts/condor_lar.sh
@@ -2071,7 +2071,7 @@ fi
 # Run optional finalization script.
 
 if [ x$FINSCRIPT != x ]; then
-  echo "Running finalization script ${FINSCRIPT}."
+  echo "Running post-validation finalization script ${FINSCRIPT}."
   ./${FINSCRIPT}
   status=$?
   if [ $status -ne 0 ]; then

--- a/scripts/condor_lar.sh
+++ b/scripts/condor_lar.sh
@@ -84,6 +84,7 @@
 # --init-script <arg>     - User initialization script execute.
 # --init-source <arg>     - User initialization script to source (bash).
 # --end-script <arg>      - User end-of-job script to execute.
+# --fin-script <arg>      - User finalization script to execute.
 # --mid-source <arg>      - User midstage initialization script to source.
 # --mid-script <arg>      - User midstage finalization script to execute.
 # --exe <arg>             - Specify art-like executable (default "lar").
@@ -237,6 +238,7 @@ PROCMAP=""
 INITSCRIPT=""
 INITSOURCE=""
 ENDSCRIPT=""
+FINSCRIPT=""
 MIDSOURCE=""
 MIDSCRIPT=""
 SAM_USER=$GRID_USER
@@ -622,6 +624,14 @@ while [ $# -gt 0 ]; do
       fi
       ;;
     
+    # User finalization script.
+    --fin-script )
+      if [ $# -gt 1 ]; then
+        FINSCRIPT=$2
+        shift
+      fi
+      ;;
+    
     # User midstage initialization source script.
     --mid-source )
       if [ $# -gt 1 ]; then
@@ -725,6 +735,7 @@ done
 #echo "INITSCRIPT=$INITSCRIPT"
 #echo "INITSOURCE=$INITSOURCE"
 #echo "ENDSCRIPT=$ENDSCRIPT"
+#echo "FINSCRIPT=$FINSCRIPT"
 #echo "MIDSOURCE=$MIDSOURCE"
 #echo "MIDSCRIPT=$MIDSCRIPT"
 #echo "VALIDATE_IN_JOB=$VALIDATE_IN_JOB"
@@ -974,6 +985,17 @@ if [ x$ENDSCRIPT != x ]; then
     chmod +x $ENDSCRIPT
   else
     echo "Finalization script $ENDSCRIPT does not exist."
+    exit 1
+  fi
+fi
+
+# Make sure finalization script exists and is executable (if specified).
+
+if [ x$FINSCRIPT != x ]; then
+  if [ -f "$FINSCRIPT" ]; then
+    chmod +x $FINSCRIPT
+  else
+    echo "Finalization script $FINSCRIPT does not exist."
     exit 1
   fi
 fi
@@ -2044,6 +2066,17 @@ if [ $VALIDATE_IN_JOB -eq 1 ]; then
       cd $curdir
     fi
 
+fi
+
+# Run optional finalization script.
+
+if [ x$FINSCRIPT != x ]; then
+  echo "Running finalization script ${FINSCRIPT}."
+  ./${FINSCRIPT}
+  status=$?
+  if [ $status -ne 0 ]; then
+    exit $status
+  fi
 fi
 
 # Make a tarball of the log directory contents, and save the tarball in the log directory.

--- a/scripts/condor_lar.sh
+++ b/scripts/condor_lar.sh
@@ -623,7 +623,7 @@ while [ $# -gt 0 ]; do
         shift
       fi
       ;;
-    
+
     # User finalization script.
     --fin-script )
       if [ $# -gt 1 ]; then
@@ -2060,26 +2060,16 @@ if [ $VALIDATE_IN_JOB -eq 1 ]; then
       for ftype in ${DATAFILETYPES[*]}; do
         dataopt="$dataopt --data_file_type $ftype"
       done
+      finopt=''
+      if [ x$FINSCRIPT != x ]; then
+        finopt="--finscript $FINSCRIPT"
+      fi
       echo "./validate_in_job.py --dir $curdir/out --logfiledir $curdir/log --outdir $OUTDIR/$OUTPUT_SUBDIR --declare $DECLARE_IN_JOB --copy $COPY_TO_FTS --maintain_parentage $MAINTAIN_PARENTAGE $dataopt"
-      ./validate_in_job.py --dir $curdir/out --logfiledir $curdir/log --outdir $OUTDIR/$OUTPUT_SUBDIR --declare $DECLARE_IN_JOB --copy $COPY_TO_FTS --maintain_parentage $MAINTAIN_PARENTAGE $dataopt
+      ./validate_in_job.py --dir $curdir/out --logfiledir $curdir/log --outdir $OUTDIR/$OUTPUT_SUBDIR --declare $DECLARE_IN_JOB --copy $COPY_TO_FTS --maintain_parentage $MAINTAIN_PARENTAGE $dataopt $finopt
       valstat=$?
       cd $curdir
     fi
 
-fi
-
-# Run optional finalization script.
-
-if [ x$FINSCRIPT != x ]; then
-  echo "Running post-validation finalization script ${FINSCRIPT}."
-  curdir=`pwd`
-  cd $curdir/log
-  ./${FINSCRIPT}
-  cd $curdir
-  status=$?
-  if [ $status -ne 0 ]; then
-    exit $status
-  fi
 fi
 
 # Make a tarball of the log directory contents, and save the tarball in the log directory.

--- a/scripts/condor_lar.sh
+++ b/scripts/condor_lar.sh
@@ -2072,7 +2072,10 @@ fi
 
 if [ x$FINSCRIPT != x ]; then
   echo "Running post-validation finalization script ${FINSCRIPT}."
+  curdir=`pwd`
+  cd $curdir/log
   ./${FINSCRIPT}
+  cd $curdir
   status=$?
   if [ $status -ne 0 ]; then
     exit $status

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -2799,7 +2799,7 @@ def dojobsub(project, stage, makeup, recur, dryrun, retain):
             f.write('echo\n')
             f.write('echo "Executing %s"\n' % os.path.basename(fin_script[0]))
             if larbatch_posix.exists(fin_script[0]):
-                f.write('./%s' % os.path.basename(fin_script[0]))
+                f.write('../%s' % os.path.basename(fin_script[0]))
             else:
                 f.write(os.path.basename(fin_script[0]))
             if len(fin_script) > 1:

--- a/scripts/project.py
+++ b/scripts/project.py
@@ -368,6 +368,8 @@
 # <stage><initscript> - Worker initialization script (condor_lar.sh --init-script).  Repeatable.
 # <stage><initsource> - Worker initialization bash source script (condor_lar.sh --init-source).
 # <stage><endscript>  - Worker finalization script (condor_lar.sh --end-script).  Repeatable.
+# <stage><finscript>  - Worker finalization script (condor_lar.sh --fin-script).  Repeatable.
+#                       Runs after final checks on output file(s) (later than endscript).
 # <stage><merge>  - Name of special histogram merging program or script (default "hadd -T",
 #                   can be overridden at each stage).
 #                   Set to "1" to generate merging metadata for artroot files.
@@ -423,7 +425,7 @@
 # <stage><fcl> - Name of fcl file.  This should come first within each <fcl> element
 #                before additional substage subelements.
 # <stage><fcl><initsource> - Initialization source script for this substage.
-# <stage><fcl><endstage> - Finalization script for this substage.
+# <stage><fcl><endscript> - Finalization script for this substage.
 # <stage><fcl><exe> - Executable to use in this substage (default "lar").
 # <stage><fcl><output> - Output file name for this substage.
 # <stage><fcl><processname> - Override fcl parameter "process_name:" in fcl wrapper.
@@ -2771,6 +2773,48 @@ def dojobsub(project, stage, makeup, recur, dryrun, retain):
         f.close()
         stage.end_script = work_end_wrapper
 
+    # Copy worker finalization scripts to work directory.
+
+    for fin_script in stage.fin_script:
+        if len(fin_script) > 0:
+            if larbatch_posix.exists(fin_script[0]):
+                work_fin_script = os.path.join(tmpworkdir, os.path.basename(fin_script[0]))
+                if fin_script[0] != work_fin_script:
+                    larbatch_posix.copy(fin_script[0], work_fin_script)
+
+    # Update stage.fin_script from list to single script.
+
+    n = len(stage.fin_script)
+    if n == 0:
+        stage.fin_script = ''
+    else:
+
+        # If there are finalization scripts, generate a wrapper finalization script
+        # fin_wrapper.sh.
+
+        work_fin_wrapper = os.path.join(tmpworkdir, 'fin_wrapper.sh')
+        f = open(work_fin_wrapper, 'w')
+        f.write('#! /bin/bash\n')
+        for fin_script in stage.fin_script:
+            f.write('echo\n')
+            f.write('echo "Executing %s"\n' % os.path.basename(fin_script[0]))
+            if larbatch_posix.exists(fin_script[0]):
+                f.write('./%s' % os.path.basename(fin_script[0]))
+            else:
+                f.write(os.path.basename(fin_script[0]))
+            if len(fin_script) > 1:
+                f.write(' %s' % ' '.join(fin_script[1:]))
+            f.write('\n')
+            f.write('status=$?\n')
+            f.write('echo "%s finished with status $status"\n' % os.path.basename(fin_script[0]))
+            f.write('if [ $status -ne 0 ]; then\n')
+            f.write('  exit $status\n')
+            f.write('fi\n')
+        f.write('echo\n')
+        f.write('echo "Done executing finalization scripts."\n')
+        f.close()
+        stage.fin_script = work_fin_wrapper
+
     # Copy worker midstage source initialization scripts to work directory.
 
     for istage in stage.mid_source:
@@ -3282,6 +3326,8 @@ def dojobsub(project, stage, makeup, recur, dryrun, retain):
         command.extend([' --init-source', os.path.basename(stage.init_source)])
     if stage.end_script != '':
         command.extend([' --end-script', os.path.basename(stage.end_script)])
+    if stage.fin_script != '':
+        command.extend([' --fin-script', os.path.basename(stage.fin_script)])
     if stage.mid_source != '':
         command.extend([' --mid-source', os.path.basename(stage.mid_source)])
     if stage.mid_script != '':

--- a/scripts/validate_in_job.py
+++ b/scripts/validate_in_job.py
@@ -8,7 +8,7 @@
 # Options:
 #
 # --dir <dir>     - Directory containing .root files on batch worker.
-# --logdir <dir>  - Log file directory on batch worker (lar.stat and .json files).
+# --logfiledir <dir> - Log file directory on batch worker (lar.stat and .json files).
 # --outdir <dir>  - Final output directory (e.g. dCache) where .root files will be copied.
 # --declare <0/1> - Flag for declaring files to sam.
 # --copy <0/1>    - Flag for copyoing files directly to dropbox.
@@ -17,6 +17,7 @@
 # --data_file_type - Specify data file type (repeatable, default "root").
 # --parents <file> - File containing parent files (same as $JOBS_PARENTS).
 # --aunts <file>   - File containing aunt files (same as $JOBS_AUNTS).
+# --finscript <script> - Run specified finalization script.
 #
 # Environment variables:
 #
@@ -172,6 +173,7 @@ def main():
     data_file_types = []
     parents_file = ''
     aunts_file = ''
+    finscript = ''
     args = sys.argv[1:]
     while len(args) > 0:
 
@@ -201,6 +203,9 @@ def main():
             del args[0:2]
         elif args[0] == '--aunts' and len(args) > 1:
             aunts_file = args[1]
+            del args[0:2]
+        elif args[0] == '--finscript' and len(args) > 1:
+            finscript = args[1]
             del args[0:2]
         else:
             print('Unknown option %s' % args[0])
@@ -419,6 +424,13 @@ def main():
                         print('No sam metadata found for %s.' % fn)
                         declare_ok = False
                         status = 1
+
+                if declare_ok:
+
+                    # If sam declaration is OK, run final check script before
+                    # (possibly) copying file to dropbox.
+
+                    print('Running final checks on file %s' % fn)
              
                 if copy_to_dropbox == 1 and declare_ok:
                     print("Copying to Dropbox")

--- a/scripts/validate_in_job.py
+++ b/scripts/validate_in_job.py
@@ -586,6 +586,8 @@ def main():
                     # Run final checking script.
 
                     print('Running post-declaration checking script %s' % finscript)
+                    sys.stdout.flush()
+                    sys.stderr.flush()
                     st = subprocess.run('../%s' % finscript)
                     rc = st.returncode
                     print('%s completed with status %d.' % (finscript, rc))


### PR DESCRIPTION
Adding xml element `<finscript>`, which element acts similar as `<endscript>`, except that `<finscript>` is invoked after output files have been declared to sam, but before output files are copied to the FTS dropbox.  Unlike `<endscript>` this gives `<finscript>` access to the final sam metadata of output files.